### PR TITLE
Improve layout

### DIFF
--- a/styles/atom-chat.less
+++ b/styles/atom-chat.less
@@ -1,11 +1,9 @@
 @import "ui-variables";
 
 .atom-chat{
+  display: flex;
+  flex-direction: column;
   position: relative;
-  width:100%;
-  height:100%;
-  z-index: 2;
-  overflow: hidden;
   width: 225px;
   min-width:200px;
   color: @text-color;
@@ -21,14 +19,18 @@
 }
 
 .chat {
-  height: 100%;
-  width: 100%;
-  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
   .chat-input {
     padding: @component-padding;
   }
 
   .chat-messages {
+    flex: 1 1 0;
+    overflow-x: hidden;
+    overflow-y: auto;
     padding: @component-padding;
     padding-top: 0;
     ul {
@@ -57,36 +59,34 @@
   }
 
   .chat-header{
+    display: block;
+    text-align: center;
     padding: @component-padding;
     line-height: 13px;
-    width: 100%;
-    z-index: 3;
     .chat-title {
       font-size:13px;
-      width:100%;
       cursor: default;
-      text-align: center;
       color: @text-color;
     }
   }
 
   .chat-footer {
-    display: block;
-    position: absolute;
-    bottom:0;
+    display: flex;
     padding: @component-icon-padding + 1px 0 @component-icon-padding @component-icon-padding;
-    width: 100%;
     border-top: 1px solid @base-border-color;
-    overflow: hidden;
     font-size: 11px;
+    .chat-room {
+      flex: 1 1 0;
+      color: @text-color;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     .add-room {
-      float: right;
       color: #35AC19;
       font-size: 13px;
+      padding-left: @component-padding;
       padding-right: @component-padding;
-    }
-    .chat-room {
-      color: @text-color;
     }
   }
 

--- a/styles/atom-chat.less
+++ b/styles/atom-chat.less
@@ -99,3 +99,6 @@
     }
   }
 }
+
+// Deprecated. Can be removed after Atom 1.6 is released
+.atom-chat{ height: 100%; }


### PR DESCRIPTION
While testing https://github.com/atom/atom/pull/9274 I noticed the messages run into the footer.

![screen shot 2016-02-09 at 1 24 37 pm](https://cloud.githubusercontent.com/assets/378023/12909248/7f30b34e-cf42-11e5-9a63-3ff42f7c9203.png)

This PR makes only the `.chat-messages` scroll, but keeps the rest visible:

![chat](https://cloud.githubusercontent.com/assets/378023/12909250/88171836-cf42-11e5-83ec-7581ab4071c5.gif)
